### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://v-chehoo.visualstudio.com/2b274901-547e-420c-bc39-da1bbebd07e0/f0eefcd2-4855-43a8-a794-4b04278d19a7/_apis/work/boardbadge/1c9f619f-8fdd-46ec-a69f-adccea467c97)](https://v-chehoo.visualstudio.com/2b274901-547e-420c-bc39-da1bbebd07e0/_boards/board/t/f0eefcd2-4855-43a8-a794-4b04278d19a7/Microsoft.RequirementCategory)
 # portfolio
 this is my portfolio


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://v-chehoo.visualstudio.com/2b274901-547e-420c-bc39-da1bbebd07e0/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.